### PR TITLE
Fix comparison in airprint-generate.py

### DIFF
--- a/airprint/airprint-generate.py
+++ b/airprint/airprint-generate.py
@@ -176,7 +176,7 @@ class AirPrintGenerate(object):
                   desc.text = 'note=%s' % (v['printer-info'])
                 service.append(desc)
 
-                if 'color-supported' in attrs and attrs['color-supported'] == 'True':
+                if 'color-supported' in attrs and attrs['color-supported'] == True:
                     color = Element('txt-record')
                     color.text = 'Color=T'
                     service.append(color)


### PR DESCRIPTION
The comparison uses the wrong type (the string `'True'` instead of the boolean literal `True`), so the condition is never true.