### PR TITLE
feat: add duplex support

### DIFF
--- a/airprint/airprint-generate.py
+++ b/airprint/airprint-generate.py
@@ -154,7 +154,6 @@ class AirPrintGenerate(object):
                 else:
                   rp = uri[2]
 
-
                 re_match = re.match(r'^//(.*):(\d+)(/.*)', rp)
                 if re_match:
                   rp = re_match.group(3)


### PR DESCRIPTION
Add detection for two-sided printing in the `airprint-generate.py`

closes #102 